### PR TITLE
fix: use swiftlang repository instead of using apple for swift-syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let products: [Product] = [
 
 let dependencies: [Package.Dependency] = [
   .package(
-    url: "https://github.com/apple/swift-syntax.git",
+    url: "https://github.com/swiftlang/swift-syntax.git",
     "510.0.0"..<"603.0.0"
   )
 ]


### PR DESCRIPTION
## Description

To fix this warning inside projects that use many macros with both `apple` and `swiftlang` reference to `swift-syntax`

```
Showing All Issues
Conflicting identity for swift-syntax: dependency 'github.com/apple/swift-syntax' and dependency 'github.com/swiftlang/swift-syntax' both point to the same package identity 'swift-syntax'.

To resolve the conflict, coordinate with the maintainer of the package that introduces the conflicting dependency. This will be escalated to an error in future versions of SwiftPM.
```